### PR TITLE
Fix click handler for map paths

### DIFF
--- a/script.js
+++ b/script.js
@@ -66,8 +66,8 @@ window.onload = function () {
         [graph].forEach(
             function (e) {
                 e.attr({cursor : 'pointer'});
-                e[0].onclick = popTable;
-                e[0].city = city;
+                e.node.onclick = popTable;
+                e.node.city = city;
                 // e.node.onmouseover = showName;
                 // e.node.onmouseout = hideName;
             }


### PR DESCRIPTION
## Summary
- ensure map path click events use `.node` instead of accessing nonexistent `[0]`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a5405cc3883268a81fe73b9490d0b